### PR TITLE
update podspec to use zip file

### DIFF
--- a/SkyWay.podspec
+++ b/SkyWay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SkyWay'
-  s.version          = '1.0.2'
+  s.version          = '1.0.3'
   s.summary          = 'SkyWay simplifies peer-to-peer data, video, and audio calls using WebRTC.'
   s.description      = <<-DESC
   "SkyWay" is a framework that enables using SkyWay in iOS apps.
@@ -9,8 +9,10 @@ SkyWay simplifies peer-to-peer data, video, and audio calls using WebRTC.
   s.homepage         = 'https://webrtc.ecl.ntt.com'
   s.license          = { :type => 'Apache License', :file => 'LICENSE.txt' }
   s.author           = { 'NTT Communications' => 'skyway@ntt.com' }
-  s.source           = { :git => 'https://github.com/skyway/skyway-ios-sdk.git', :tag => "v1.0.2" }
-  s.exclude_files = 'examples'
+  s.source           = { :http => 'https://github.com/skyway/skyway-ios-sdk/releases/download/v1.0.3/SkyWay_iOS_1.0.3.zip', :flatten => true }
   s.ios.deployment_target = '8.0'
   s.vendored_frameworks = 'SkyWay.framework'
+  s.source_files  = 'SkyWay.framework/Headers/*.h'
+  s.preserve_paths  = 'SkyWay.framework'
+  s.xcconfig  = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/SkyWay.framework/**"' }
 end


### PR DESCRIPTION
bitcode対応にて、ライブラリ肥大化のため、ファイルをgithubではなく、zipファイルで落とすように変更しました。
(ライブラリファイルは肥大していますが、端末に入る時には最適化され小さくなります)