### PR TITLE
add Mute / Unmute button in p2p-videochat

### DIFF
--- a/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/Base.lproj/Main.storyboard
+++ b/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/Base.lproj/Main.storyboard
@@ -62,6 +62,22 @@
                                     <action selector="onSwitchCameraButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="OEH-bA-uRj"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hxk-qN-DP9">
+                                <rect key="frame" x="96" y="551" width="35" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Mute"/>
+                                <connections>
+                                    <action selector="onMuteButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AAl-1z-6bR"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Shx-K5-Zl2">
+                                <rect key="frame" x="86" y="589" width="55" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Unmute"/>
+                                <connections>
+                                    <action selector="onUnmuteButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZZl-bI-gW9"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>

--- a/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/Base.lproj/Main.storyboard
+++ b/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/Base.lproj/Main.storyboard
@@ -62,20 +62,20 @@
                                     <action selector="onSwitchCameraButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="OEH-bA-uRj"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hxk-qN-DP9">
-                                <rect key="frame" x="96" y="551" width="35" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Shx-K5-Zl2">
+                                <rect key="frame" x="64" y="589" width="98" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Mute"/>
+                                <state key="normal" title="Audio Unmute"/>
                                 <connections>
-                                    <action selector="onMuteButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AAl-1z-6bR"/>
+                                    <action selector="onAudioUnmuteButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="GRf-Hm-A8t"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Shx-K5-Zl2">
-                                <rect key="frame" x="86" y="589" width="55" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hxk-qN-DP9">
+                                <rect key="frame" x="74" y="551" width="78" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Unmute"/>
+                                <state key="normal" title="Audio Mute"/>
                                 <connections>
-                                    <action selector="onUnmuteButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZZl-bI-gW9"/>
+                                    <action selector="onAudioMuteButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6Ug-1f-15S"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
+++ b/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
@@ -288,7 +288,7 @@ static NSString *const kDomain = @"yourDomain";
 //
 // Action for muteButton
 //
-- (IBAction)onMuteButtonClicked:(id)sender {
+- (IBAction)onAudioMuteButtonClicked:(id)sender {
     if(nil == _localStream) {
         return;
     }
@@ -299,7 +299,7 @@ static NSString *const kDomain = @"yourDomain";
 //
 // Action for unmuteButton
 //
-- (IBAction)onUnmuteButtonClicked:(id)sender {
+- (IBAction)onAudioUnmuteButtonClicked:(id)sender {
     if(nil == _localStream) {
         return;
     }

--- a/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
+++ b/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
@@ -285,4 +285,26 @@ static NSString *const kDomain = @"yourDomain";
     [_localStream setCameraPosition:pos];
 }
 
+//
+// Action for muteButton
+//
+- (IBAction)onMuteButtonClicked:(id)sender {
+    if(nil == _localStream) {
+        return;
+    }
+
+    [_localStream setEnableAudioTrack:0 enable:false];
+}
+
+//
+// Action for unmuteButton
+//
+- (IBAction)onUnmuteButtonClicked:(id)sender {
+    if(nil == _localStream) {
+        return;
+    }
+
+    [_localStream setEnableAudioTrack:0 enable:true];
+}
+
 @end


### PR DESCRIPTION
Added a pair of button to mute and to unmute AudioTrack in p2p-videochat example.  This is an example for a part of SkyWay iOS SDK feature.