### PR TITLE
Remove prefix of room name in mesh/sfu examples

### DIFF
--- a/examples/objective-c/mesh-textchat/eclwebrtc-ios-sample-mesh-textchat/Info.plist
+++ b/examples/objective-c/mesh-textchat/eclwebrtc-ios-sample-mesh-textchat/Info.plist
@@ -20,6 +20,10 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>This sample uses a mic device for video chat.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This sample uses a camera device for video chat.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/examples/objective-c/mesh-textchat/eclwebrtc-ios-sample-mesh-textchat/ViewController.m
+++ b/examples/objective-c/mesh-textchat/eclwebrtc-ios-sample-mesh-textchat/ViewController.m
@@ -100,7 +100,7 @@ static NSString *const kDomain = @"yourDomain";
     //
     SKWRoomOption* option = [[SKWRoomOption alloc] init];
     option.mode = SKW_ROOM_MODE_MESH;
-    NSString* roomName = [NSString stringWithFormat:@"mesh_text_%@", _roomNameField.text];
+    NSString* roomName = [NSString stringWithFormat:@"%@", _roomNameField.text];
     _meshRoom = (SKWMeshRoom*)[_peer joinRoomWithName:roomName options:option];
     
     //

--- a/examples/objective-c/mesh-videochat/eclwebrtc-ios-sample-mesh-videochat/ViewController.m
+++ b/examples/objective-c/mesh-videochat/eclwebrtc-ios-sample-mesh-videochat/ViewController.m
@@ -116,7 +116,7 @@ static NSString *const kDomain = @"yourDomain";
     SKWRoomOption* option = [[SKWRoomOption alloc] init];
     option.mode = SKW_ROOM_MODE_MESH;
     option.stream = _localStream;
-    NSString* roomName = [NSString stringWithFormat:@"mesh_video_%@", _roomNameField.text];
+    NSString* roomName = [NSString stringWithFormat:@"%@", _roomNameField.text];
     _meshRoom = (SKWMeshRoom*)[_peer joinRoomWithName:roomName options:option];
     
     //

--- a/examples/objective-c/sfu-textchat/eclwebrtc-ios-sample-sfu-textchat/ViewController.m
+++ b/examples/objective-c/sfu-textchat/eclwebrtc-ios-sample-sfu-textchat/ViewController.m
@@ -100,7 +100,7 @@ static NSString *const kDomain = @"yourDomain";
     //
     SKWRoomOption* option = [[SKWRoomOption alloc] init];
     option.mode = SKW_ROOM_MODE_SFU;
-    NSString* roomName = [NSString stringWithFormat:@"sfu_text_%@", _roomNameField.text];
+    NSString* roomName = [NSString stringWithFormat:@"%@", _roomNameField.text];
     _sfuRoom = (SKWSFURoom*)[_peer joinRoomWithName:roomName options:option];
     
     //

--- a/examples/objective-c/sfu-videochat/eclwebrtc-ios-sample-sfu-videochat/ViewController.m
+++ b/examples/objective-c/sfu-videochat/eclwebrtc-ios-sample-sfu-videochat/ViewController.m
@@ -116,7 +116,7 @@ static NSString *const kDomain = @"yourDomain";
     SKWRoomOption* option = [[SKWRoomOption alloc] init];
     option.mode = SKW_ROOM_MODE_SFU;
     option.stream = _localStream;
-    NSString* roomName = [NSString stringWithFormat:@"sfu_video_%@", _roomNameField.text];
+    NSString* roomName = [NSString stringWithFormat:@"%@", _roomNameField.text];
     _sfuRoom = (SKWSFURoom*)[_peer joinRoomWithName:roomName options:option];
     
     //


### PR DESCRIPTION
[Background]
- In mesh/sfu room examples, iOS SDK examples have the room name with the prefix.
To connect iOS SDK examples with [new JS SDK examples](https://github.com/skyway/skyway-js-sdk/tree/master/examples/room), JS SDK example's room name must add the prefix. (eg. `mesh_video_{roomname}`)
- In mesh room example, application crashes because of configurations of `Info.plist`

In this PR,  above are fixed.

[After]
In mesh/sfu room example, iOS SDK examples and new JS SDK examples can connect completely same room name.