### PR TITLE
fix/support p2p-textchat example for iPad

### DIFF
--- a/examples/objective-c/p2p-textchat/eclwebrtc-ios-sample-p2p-textchat/ViewController.m
+++ b/examples/objective-c/p2p-textchat/eclwebrtc-ios-sample-p2p-textchat/ViewController.m
@@ -320,6 +320,8 @@ static NSString *const kDomain = @"yourDomain";
                                   }];
         [ac addAction:aaTypes];
     }
+    ac.popoverPresentationController.sourceView = self.view;
+    ac.popoverPresentationController.sourceRect = _dataTypeButton.frame;
     
     [self presentViewController:ac animated:YES completion:nil];
 }


### PR DESCRIPTION
# WHAT
- Add `popoverPresentationController` setting to `UIAlertController`

# WHY
- If there is no `popoverPresentationController` setting in `UIAlertController`, p2p-textchat will crash on iPad.