### PR TITLE
Release v3.1.0

### DIFF
--- a/SkyWay.podspec
+++ b/SkyWay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SkyWay'
-  s.version          = '3.0.1'
+  s.version          = '3.1.0'
   s.summary          = 'SkyWay simplifies peer-to-peer data, video, and audio calls using WebRTC.'
   s.description      = <<-DESC
   "SkyWay" is a framework that enables using SkyWay in iOS apps.
@@ -9,7 +9,7 @@ SkyWay simplifies peer-to-peer data, video, and audio calls using WebRTC.
   s.homepage         = 'https://webrtc.ecl.ntt.com'
   s.license          = { :type => 'Apache License', :file => 'LICENSE.txt' }
   s.author           = { 'NTT Communications' => 'skyway@ntt.com' }
-  s.source           = { :http => 'https://github.com/skyway/skyway-ios-sdk/releases/download/v3.0.1/SkyWay_iOS_3.0.1.zip', :flatten => true }
+  s.source           = { :http => 'https://github.com/skyway/skyway-ios-sdk/releases/download/v3.1.0/SkyWay_iOS_3.1.0.zip', :flatten => true }
   s.ios.deployment_target = '10.0'
   s.vendored_frameworks = 'SkyWay.framework'
   s.source_files  = 'SkyWay.framework/Headers/*.h'

--- a/examples/objective-c/p2p-call/eclwebrtc-ios-sample-p2p-call/Viewcontroller.m
+++ b/examples/objective-c/p2p-call/eclwebrtc-ios-sample-p2p-call/Viewcontroller.m
@@ -327,7 +327,7 @@ typedef NS_ENUM(NSInteger, CallState){
         //
         
         [self closeRemoteStream];
-        [_mediaConnection close];
+        [_mediaConnection close:YES];
         [_signalingChannel close];
         _callState = CALL_STATE_TERMINATED;
         [self updateActionButtonTitle];

--- a/examples/objective-c/p2p-call/eclwebrtc-ios-sample-p2p-call/Viewcontroller.m
+++ b/examples/objective-c/p2p-call/eclwebrtc-ios-sample-p2p-call/Viewcontroller.m
@@ -163,7 +163,7 @@ typedef NS_ENUM(NSInteger, CallState){
         [self closeRemoteStream];
         [self unsetMediaCallbacks];
         self->_mediaConnection = nil;
-        [self->_signalingChannel close];
+        [self->_signalingChannel close:YES];
         self->_callState = CALL_STATE_TERMINATED;
         [self updateActionButtonTitle];
 
@@ -194,14 +194,14 @@ typedef NS_ENUM(NSInteger, CallState){
         NSLog(@"[On/Data] %@", message);
         
         if ([message isEqualToString:@"reject"]) {
-            [self->_mediaConnection close];
-            [self->_signalingChannel close];
+            [self->_mediaConnection close:YES];
+            [self->_signalingChannel close:YES];
             self->_callState = CALL_STATE_TERMINATED;
             [self updateActionButtonTitle];
         }
         else if ([message isEqualToString:@"cancel"]) {
-            [self->_mediaConnection close];
-            [self->_signalingChannel close];
+            [self->_mediaConnection close:YES];
+            [self->_signalingChannel close:YES];
             self->_callState = CALL_STATE_TERMINATED;
             [self updateActionButtonTitle];
             [self dismissIncomingCallAlert];
@@ -328,7 +328,7 @@ typedef NS_ENUM(NSInteger, CallState){
         
         [self closeRemoteStream];
         [_mediaConnection close:YES];
-        [_signalingChannel close];
+        [_signalingChannel close:YES];
         _callState = CALL_STATE_TERMINATED;
         [self updateActionButtonTitle];
         

--- a/examples/objective-c/p2p-textchat/eclwebrtc-ios-sample-p2p-textchat/ViewController.m
+++ b/examples/objective-c/p2p-textchat/eclwebrtc-ios-sample-p2p-textchat/ViewController.m
@@ -285,7 +285,7 @@ static NSString *const kDomain = @"yourDomain";
         // Close a DataConnection
         //
         
-        [_dataConnection close];
+        [_dataConnection close:YES];
         _dataConnection = nil;
     }
 }

--- a/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
+++ b/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
@@ -190,7 +190,7 @@ static NSString *const kDomain = @"yourDomain";
         [_remoteStream removeVideoRenderer:_remoteView track:0];
     }
     
-    [_remoteStream close];
+    [_remoteStream close:YES];
     _remoteStream = nil;
 }
 

--- a/examples/swift/swift/viewcontroller/DataConnectionViewController.swift
+++ b/examples/swift/swift/viewcontroller/DataConnectionViewController.swift
@@ -43,7 +43,7 @@ class DataConnectionViewController: UIViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        self.dataConnection?.close()
+        self.dataConnection?.close(true)
         self.peer?.disconnect()
         self.peer?.destroy()
     }
@@ -64,7 +64,7 @@ class DataConnectionViewController: UIViewController {
     }
     
     @IBAction func tapEndCall(){
-        self.dataConnection?.close()
+        self.dataConnection?.close(true)
         self.changeConnectionStatusUI(connected: false)
     }
     

--- a/examples/swift/swift/viewcontroller/MediaConnectionViewController.swift
+++ b/examples/swift/swift/viewcontroller/MediaConnectionViewController.swift
@@ -28,7 +28,7 @@ class MediaConnectionViewController: UIViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        self.mediaConnection?.close()
+        self.mediaConnection?.close(true)
         self.peer?.destroy()
     }
 
@@ -48,7 +48,7 @@ class MediaConnectionViewController: UIViewController {
     }
 
     @IBAction func tapEndCall(){
-        self.mediaConnection?.close()
+        self.mediaConnection?.close(true)
         self.changeConnectionStatusUI(connected: false)
     }
 

--- a/release-notes.en.md
+++ b/release-notes.en.md
@@ -2,6 +2,14 @@
 
 [日本語](./release-notes.md)
 
+## [Version 3.1.0](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.1.0)
+
+### Added
+- Add an `forceClose` option when calling `SKWMediaConnection`, `SKWDataConnection` to signal intention to disconnection to the remote peer instantly.
+
+### Deprecated
+- The `NO` default value of `forceClose` is deprecated and may be changed to `YES` in future versions.
+
 ## [Version 3.0.1](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.0.1)
 
 ### Fixed

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,14 @@
 
 [English](./release-notes.en.md)
 
+## [Version 3.1.0](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.1.0)
+### Added
+- `SKWMediaConnection`, `SKWDataConnection` に `forceClose` オプションを追加しました。このオプションを有効にすると、接続相手においても各 `Connection` が即座にクローズします。
+
+### Deprecated
+- `forceClose` のデフォルト値 `NO` は将来のバージョンでは `YES` に変更される可能性があります。
+
+
 ## [Version 3.0.1](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.0.1)
 
 ### Fixed

--- a/release-notes.md
+++ b/release-notes.md
@@ -9,7 +9,6 @@
 ### Deprecated
 - `forceClose` のデフォルト値 `NO` は将来のバージョンでは `YES` に変更される可能性があります。
 
-
 ## [Version 3.0.1](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.0.1)
 
 ### Fixed


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Feature

### Summary
- Add an `forceClose` option when calling `SKWMediaConnection`, `SKWDataConnection` to signal intention to disconnection to the remote peer instantly.
- The `NO` default value of `forceClose` is deprecated and may be changed to `YES` in future versions.
- Add forceClose option to examples

### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
