### PR TITLE
Release v3.2.0

### DIFF
--- a/SkyWay.podspec
+++ b/SkyWay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SkyWay'
-  s.version          = '3.1.0'
+  s.version          = '3.2.0'
   s.summary          = 'SkyWay simplifies peer-to-peer data, video, and audio calls using WebRTC.'
   s.description      = <<-DESC
   "SkyWay" is a framework that enables using SkyWay in iOS apps.
@@ -9,7 +9,7 @@ SkyWay simplifies peer-to-peer data, video, and audio calls using WebRTC.
   s.homepage         = 'https://webrtc.ecl.ntt.com'
   s.license          = { :type => 'Apache License', :file => 'LICENSE.txt' }
   s.author           = { 'NTT Communications' => 'skyway@ntt.com' }
-  s.source           = { :http => 'https://github.com/skyway/skyway-ios-sdk/releases/download/v3.1.0/SkyWay_iOS_3.1.0.zip', :flatten => true }
+  s.source           = { :http => 'https://github.com/skyway/skyway-ios-sdk/releases/download/v3.2.0/SkyWay_iOS_3.2.0.zip', :flatten => true }
   s.ios.deployment_target = '10.0'
   s.vendored_frameworks = 'SkyWay.framework'
   s.source_files  = 'SkyWay.framework/Headers/*.h'

--- a/release-notes.en.md
+++ b/release-notes.en.md
@@ -2,17 +2,26 @@
 
 [日本語](./release-notes.md)
 
+## [Version 3.2.0](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.2.0) - 2020-11-16
+
+### Added
+
+- Added `tryReconnectMedia` and `tryReconnectData` option to `PeerOption`. This enables to try to reconnect automatically when the WebRTC communication state is temporarily disconnected due to unstable communication or other reasons. The default value is false.
+
 ## [Version 3.1.0](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.1.0) - 2020-11-02
 
 ### Added
+
 - Add an `forceClose` option when calling `SKWMediaConnection`, `SKWDataConnection` to signal intention to disconnection to the remote peer instantly.
 
 ### Deprecated
+
 - The `NO` default value of `forceClose` is deprecated and may be changed to `YES` in future versions.
 
 ## [Version 3.0.1](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.0.1) - 2020-10-05
 
 ### Fixed
+
 - Fixed to automatically try to reconnect when WebRTC communication state is temporarily disconnected due to unstable communication or other reasons.
 
 ## [Version 3.0.0](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.0.0) - 2020-08-31

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,16 +2,24 @@
 
 [English](./release-notes.en.md)
 
+## [Version 3.2.0](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.2.0) - 2020-11-16
+### Added
+
+- Peer オプションに `tryReconnectMedia` と `tryReconnectData` のオプションを追加しました。このオプションを有効にすることで、WebRTC通信が一時的な切断状態になった場合に自動再接続を試行するようになります。デフォルトではこのオプションは無効です。
+
 ## [Version 3.1.0](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.1.0) - 2020-11-02
 ### Added
+
 - `SKWMediaConnection`, `SKWDataConnection` に `forceClose` オプションを追加しました。このオプションを有効にすると、接続相手においても各 `Connection` が即座にクローズします。
 
 ### Deprecated
+
 - `forceClose` のデフォルト値 `NO` は将来のバージョンでは `YES` に変更される可能性があります。
 
 ## [Version 3.0.1](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.0.1) - 2020-10-05
 
 ### Fixed
+
 - 通信状態が不安定等の理由により、WebRTC通信が一時的な切断状態になった場合に、自動で再接続を試行するように修正しました。
 
 ## [Version 3.0.0](https://github.com/skyway/skyway-ios-sdk/releases/tag/v3.0.0) - 2020-08-31


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Documentation content changes

### Summary

Update release notes for v3.2.0.

Added `tryReconnectMedia` and `tryReconnectData` option to `PeerOption`. This enables to try to reconnect automatically when the WebRTC communication state is temporarily disconnected due to unstable communication or other reasons. The default value is false.

### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
