### PR TITLE
Stop using peer's DISCONNECTED event and disconnect() in examples

### DIFF
--- a/examples/objective-c/mesh-textchat/eclwebrtc-ios-sample-mesh-textchat/ViewController.m
+++ b/examples/objective-c/mesh-textchat/eclwebrtc-ios-sample-mesh-textchat/ViewController.m
@@ -61,7 +61,6 @@ static NSString *const kDomain = @"yourDomain";
         self->_peer = nil;
     }];
     
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:^(NSObject* obj) {}];
     [_peer on:SKW_PEER_EVENT_ERROR callback:^(NSObject* obj) {}];
     
 }

--- a/examples/objective-c/mesh-videochat/eclwebrtc-ios-sample-mesh-videochat/ViewController.m
+++ b/examples/objective-c/mesh-videochat/eclwebrtc-ios-sample-mesh-videochat/ViewController.m
@@ -75,7 +75,6 @@ static NSString *const kDomain = @"yourDomain";
         self->_peer = nil;
     }];
     
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:^(NSObject* obj) {}];
     [_peer on:SKW_PEER_EVENT_ERROR callback:^(NSObject* obj) {}];
     
 }

--- a/examples/objective-c/p2p-call/Podfile
+++ b/examples/objective-c/p2p-call/Podfile
@@ -1,4 +1,4 @@
-platform :ios,'9.0'
+platform :ios,'10.0'
 use_frameworks!
 
 def install_pods

--- a/examples/objective-c/p2p-call/eclwebrtc-ios-sample-p2p-call/Viewcontroller.m
+++ b/examples/objective-c/p2p-call/eclwebrtc-ios-sample-p2p-call/Viewcontroller.m
@@ -97,7 +97,6 @@ typedef NS_ENUM(NSInteger, CallState){
     }];
     
     [_peer on:SKW_PEER_EVENT_CLOSE callback:^(NSObject* obj) {}];
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:^(NSObject* obj) {}];
     [_peer on:SKW_PEER_EVENT_ERROR callback:^(NSObject* obj) {
         SKWPeerError* err = (SKWPeerError *)obj;
         NSLog(@"%@", err);
@@ -221,7 +220,6 @@ typedef NS_ENUM(NSInteger, CallState){
     [_peer on:SKW_PEER_EVENT_CONNECTION callback:nil];
     [_peer on:SKW_PEER_EVENT_CALL callback:nil];
     [_peer on:SKW_PEER_EVENT_CLOSE callback:nil];
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:nil];
     [_peer on:SKW_PEER_EVENT_ERROR callback:nil];
 }
 

--- a/examples/objective-c/p2p-textchat/eclwebrtc-ios-sample-p2p-textchat/ViewController.m
+++ b/examples/objective-c/p2p-textchat/eclwebrtc-ios-sample-p2p-textchat/ViewController.m
@@ -81,7 +81,6 @@ static NSString *const kDomain = @"yourDomain";
     }];
     
     [_peer on:SKW_PEER_EVENT_CLOSE callback:^(NSObject* obj) {}];
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:^(NSObject* obj) {}];
     [_peer on:SKW_PEER_EVENT_ERROR callback:^(NSObject* obj) {}];
     
 }
@@ -121,7 +120,6 @@ static NSString *const kDomain = @"yourDomain";
     [_peer on:SKW_PEER_EVENT_CONNECTION callback:nil];
     [_peer on:SKW_PEER_EVENT_CALL callback:nil];
     [_peer on:SKW_PEER_EVENT_CLOSE callback:nil];
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:nil];
     [_peer on:SKW_PEER_EVENT_ERROR callback:nil];
 }
 

--- a/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
+++ b/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
@@ -188,7 +188,7 @@ static NSString *const kDomain = @"yourDomain";
         [_remoteStream removeVideoRenderer:_remoteView track:0];
     }
     
-    [_remoteStream close:YES];
+    [_remoteStream close];
     _remoteStream = nil;
 }
 

--- a/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
+++ b/examples/objective-c/p2p-videochat/eclwebrtc-ios-sample-p2p-videochat/ViewController.m
@@ -77,7 +77,6 @@ static NSString *const kDomain = @"yourDomain";
     }];
     
     [_peer on:SKW_PEER_EVENT_CLOSE callback:^(NSObject* obj) {}];
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:^(NSObject* obj) {}];
     [_peer on:SKW_PEER_EVENT_ERROR callback:^(NSObject* obj) {}];
     
 }
@@ -161,7 +160,6 @@ static NSString *const kDomain = @"yourDomain";
     [_peer on:SKW_PEER_EVENT_CONNECTION callback:nil];
     [_peer on:SKW_PEER_EVENT_CALL callback:nil];
     [_peer on:SKW_PEER_EVENT_CLOSE callback:nil];
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:nil];
     [_peer on:SKW_PEER_EVENT_ERROR callback:nil];
 }
 

--- a/examples/objective-c/sfu-textchat/eclwebrtc-ios-sample-sfu-textchat/ViewController.m
+++ b/examples/objective-c/sfu-textchat/eclwebrtc-ios-sample-sfu-textchat/ViewController.m
@@ -61,7 +61,6 @@ static NSString *const kDomain = @"yourDomain";
         self->_peer = nil;
     }];
     
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:^(NSObject* obj) {}];
     [_peer on:SKW_PEER_EVENT_ERROR callback:^(NSObject* obj) {}];
     
 }

--- a/examples/objective-c/sfu-videochat/eclwebrtc-ios-sample-sfu-videochat/ViewController.m
+++ b/examples/objective-c/sfu-videochat/eclwebrtc-ios-sample-sfu-videochat/ViewController.m
@@ -75,7 +75,6 @@ static NSString *const kDomain = @"yourDomain";
         self->_peer = nil;
     }];
     
-    [_peer on:SKW_PEER_EVENT_DISCONNECTED callback:^(NSObject* obj) {}];
     [_peer on:SKW_PEER_EVENT_ERROR callback:^(NSObject* obj) {}];
     
 }

--- a/examples/swift/swift/viewcontroller/DataConnectionViewController.swift
+++ b/examples/swift/swift/viewcontroller/DataConnectionViewController.swift
@@ -44,7 +44,6 @@ class DataConnectionViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.dataConnection?.close(true)
-        self.peer?.disconnect()
         self.peer?.destroy()
     }
 


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Other (please describe):

### Summary

- Stop using peer's DISCONNECTED event and disconnect()
- Fixed a wrong argument in examples/p2p-videochat
- Fixed target version to v10.0 in example's Podfile

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
